### PR TITLE
Add client version check

### DIFF
--- a/src/market.rs
+++ b/src/market.rs
@@ -497,6 +497,19 @@ impl System {
             return serde_json::to_string(&SysStateResponse::RequestNotAllowed).unwrap();
         }
         match request {
+            SysStateRequest::CheckVersion { version } => {
+                if version == ADBORC_VERSION {
+                    serde_json::to_string(&SysStateResponse::ClientOk).unwrap()
+                } else {
+                    serde_json::to_string(&SysStateResponse::ClientError {
+                        reason: format!(
+                            "Client version {} is not supported by listener version: {}",
+                            version, ADBORC_VERSION
+                        ),
+                    })
+                    .unwrap()
+                }
+            }
             SysStateRequest::GetState => {
                 let state = SysState::get_min_state();
                 serde_json::to_string(&SysStateResponse::CurrentSysState { state }).unwrap()

--- a/src/market/request.rs
+++ b/src/market/request.rs
@@ -19,6 +19,9 @@ pub enum Request {
 /// from the local TCPClient.
 #[derive(Serialize, Deserialize)]
 pub enum SysStateRequest {
+    CheckVersion {
+        version: String,
+    },
     GetState,
     GetPeerId,
     SystemCheck,
@@ -114,6 +117,10 @@ pub enum SysStateResponse {
     RequestProcessingError {
         reason: String,
     },
+    ClientOk,
+    ClientError {
+        reason: String,
+    },
 }
 
 impl Display for SysStateResponse {
@@ -178,6 +185,8 @@ impl Display for SysStateResponse {
             SysStateResponse::RequestProcessingError { reason } => {
                 write!(f, "Error processesing request: {}", reason)
             }
+            SysStateResponse::ClientOk => write!(f, "Client OK"),
+            SysStateResponse::ClientError { reason } => write!(f, "{}", reason),
         }
     }
 }


### PR DESCRIPTION
This patch partially resolves #4 by adding a version check to the client. The client will now send a version check request to the server and will not proceed if the server version is not compatible.

The reason this only partially resolves #4 is that the for client version pre-0.2.0, this check is not performed and the client will proceed without version check, possibly encountering an unhelpful error message later on.