### PR TITLE
Move `cli` module out of library

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
-use crate::market::{request::*, DeviceFilter, DeviceFilterVec, SysState};
-use crate::net::TCPClient;
-use crate::util::{
+use adborc::market::{request::*, DeviceFilter, DeviceFilterVec, SysState};
+use adborc::net::TCPClient;
+use adborc::util::{
     adb_utils::{self, ScrcpyCliArgs, SCRCPY_SHORTCUT_HELP},
     SysStateDefaultConfig, ADBORC_VERSION,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,4 @@ pub mod market;
 
 pub mod util;
 
-pub mod cli;
-
 mod noise;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
-use adborc::cli::Cli;
+mod cli;
+
 use clap::Parser;
+use cli::Cli;
 use env_logger::{Builder, Env};
 use std::io::Write;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,8 @@ pub const MIN_ADB_REV: u8 = 33;
 /// Minimim `scrcpy` version required. Only used for `consumer` mode.
 /// This is required if device screen mirroring and control is required.
 pub const MIN_SCRCPY_VER: u8 = 13;
+/// Current version of `adborc`.
+pub const ADBORC_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Interval used for sending `heartbeat` messages to the marketmaker.
 /// This is used by both `consumer` and `supplier` modes.
@@ -32,8 +34,6 @@ pub(crate) const CONNECTION_TIMEOUT: Duration = Duration::from_secs(3);
 /// Byte representation of the string "0009host:kill".
 pub(crate) const ADB_KILL_SERVER_COMMAND: &[u8; 13] =
     b"\x30\x30\x30\x39\x68\x6f\x73\x74\x3a\x6b\x69\x6c\x6c";
-
-pub(crate) const ADBORC_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Logfile name for logging standard output of the executable.
 pub const STDOUT_LOGFILE: &str = "adborc_stdout.log";

--- a/src/util/scrcpy_utils.rs
+++ b/src/util/scrcpy_utils.rs
@@ -162,7 +162,7 @@ pub struct ScrcpyCliArgs {
     no_display: bool,
 }
 
-pub(crate) fn get_scrcpy_args(args: ScrcpyCliArgs) -> Vec<ScrCpyArgs> {
+pub fn get_scrcpy_args(args: ScrcpyCliArgs) -> Vec<ScrCpyArgs> {
     let mut scrcpy_args = Vec::new();
     if let Some(max_size) = args.max_size {
         scrcpy_args.push(ScrCpyArgs::MaxSize(max_size));


### PR DESCRIPTION
This patch fixes #9 by moving the `cli` module out of the library and into the binary crate. This removes unnecessary bloat in the library as `cli` is only used by the binary crate.