### PR TITLE
Add stop-scrcpy subcommand for consumer

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -273,6 +273,8 @@ pub enum ConsumerCommands {
         args: ScrcpyCliArgs,
     },
     /// Stop device screen mirroring for a device.
+    /// Note: This doesn't work if the Consumer and Supplier are on the same machine.
+    ///       see: https://github.com/mobi-nex/adborc/issues/16 for more information. 
     StopScrcpy {
         /// `device_id` of the device to stop scrcpy for.
         #[clap(value_parser)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,6 +271,12 @@ pub enum ConsumerCommands {
         #[clap(flatten)]
         args: ScrcpyCliArgs,
     },
+    /// Stop device screen mirroring for a device.
+    StopScrcpy {
+        /// `device_id` of the device to stop scrcpy for.
+        #[clap(value_parser)]
+        device: String,
+    },
     /// Set the default arguments for `scrcpy`.
     SetScrcpyArgs(ScrcpyCliArgs),
     /// Get the default arguments for `scrcpy` if set using `adborc consumer set-scrcpy-args`.
@@ -846,6 +852,17 @@ fn process_consumer_command(command: ConsumerCommands, client: TCPClient) {
             let request = serde_json::to_string(&Request::Consumer(ConsumerRequest::StartScrCpy {
                 device_id: device,
                 scrcpy_args,
+            }))
+            .unwrap();
+            let response = client
+                .send(&request, None)
+                .unwrap_or_else(|e| map_processing_error(e, ResponseType::Consumer));
+            let response = serde_json::from_str::<ConsumerResponse>(&response).unwrap();
+            println!("{}", response);
+        }
+        ConsumerCommands::StopScrcpy { device } => {
+            let request = serde_json::to_string(&Request::Consumer(ConsumerRequest::StopScrCpy {
+                device_id: device,
             }))
             .unwrap();
             let response = client

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -697,14 +697,7 @@ fn process_consumer_command(command: ConsumerCommands, client: TCPClient) {
             println!("{}", response);
         }
         ConsumerCommands::StopScrcpy { device } => {
-            let request = serde_json::to_string(&Request::Consumer(ConsumerRequest::StopScrCpy {
-                device_id: device,
-            }))
-            .unwrap();
-            let response = client
-                .send(&request, None)
-                .unwrap_or_else(|e| map_processing_error(e, ResponseType::Consumer));
-            let response = serde_json::from_str::<ConsumerResponse>(&response).unwrap();
+            let response = send_request(ConsumerRequest::StopScrCpy { device_id: device }, &client);
             println!("{}", response);
         }
         ConsumerCommands::SetScrcpyArgs(args) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,5 @@ fn main() {
         })
         .init();
 
-    let cli = Cli::parse();
-    cli.process();
+    Cli::parse().process();
 }

--- a/src/market.rs
+++ b/src/market.rs
@@ -16,7 +16,6 @@ use blake2::{digest::consts::U16, Blake2s, Digest};
 use lazy_static::lazy_static;
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
-use serde_json;
 use snow::Keypair;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Display, Formatter, Write};

--- a/src/market/consumer.rs
+++ b/src/market/consumer.rs
@@ -1134,20 +1134,19 @@ impl Consumer {
             }
             ConsumerRequest::StopScrCpy { device_id } if peer_addr.ip().is_loopback() => {
                 if !ConsumerState::is_device_reserved(&device_id) {
-                    return serde_json::to_string(&ConsumerResponse::StopScrCpyFailure {
+                    return ConsumerResponse::StopScrCpyFailure {
                         reason: "Cannot stop mirroring for a device that is not reserved."
                             .to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 if let Err(e) = Consumer::stop_scrcpy(&device_id) {
-                    serde_json::to_string(&ConsumerResponse::StopScrCpyFailure {
+                    ConsumerResponse::StopScrCpyFailure {
                         reason: format!("Could not stop scrcpy: {}", e),
-                    })
-                    .unwrap()
+                    }
+                    .to_json()
                 } else {
-                    serde_json::to_string(&ConsumerResponse::StopScrCpySuccess { device_id })
-                        .unwrap()
+                    ConsumerResponse::StopScrCpySuccess { device_id }.to_json()
                 }
             }
 

--- a/src/market/request.rs
+++ b/src/market/request.rs
@@ -4,6 +4,7 @@ use super::{supplier::SupplierStateMin, DeviceFilterVec, *};
 use consumer::ConsumerStateMin;
 use marketmaker::MarketMakerMinState;
 use serde::Serialize;
+use serde_json;
 use std::str::FromStr;
 
 /// Wraps the response in the required `Response` enum and serializes it.

--- a/src/market/request.rs
+++ b/src/market/request.rs
@@ -665,6 +665,9 @@ pub enum ConsumerRequest {
         device_id: String,
         scrcpy_args: Vec<ScrCpyArgs>,
     },
+    StopScrCpy {
+        device_id: String,
+    },
     SetScrCpyDefaults {
         scrcpy_args: Vec<ScrCpyArgs>,
     },
@@ -718,6 +721,12 @@ pub enum ConsumerResponse {
         device_id: String,
     },
     StartScrCpyFailure {
+        reason: String,
+    },
+    StopScrCpySuccess {
+        device_id: String,
+    },
+    StopScrCpyFailure {
         reason: String,
     },
     ScrCpyDefaultsSet {
@@ -801,6 +810,16 @@ impl Display for ConsumerResponse {
             }
             ConsumerResponse::StartScrCpyFailure { reason } => {
                 write!(f, "Screen mirroring failed: {}", reason)
+            }
+            ConsumerResponse::StopScrCpySuccess { device_id } => {
+                write!(
+                    f,
+                    "Stopped screen mirroring successfully for device: {}",
+                    device_id
+                )
+            }
+            ConsumerResponse::StopScrCpyFailure { reason } => {
+                write!(f, "Error stopping screen mirroring: {}", reason)
             }
             ConsumerResponse::ScrCpyDefaultsSet { args } => {
                 writeln!(f, "ScrCpy defaults set:").unwrap();

--- a/src/net.rs
+++ b/src/net.rs
@@ -510,7 +510,7 @@ impl PortForwarder {
                     debug!("Sent stop signal to portforwarder");
                     // Portforwader checks for stop signal only when a new connection is received.
                     // Force a new connection to be established to stop the server.
-                    if TcpStream::connect(self.src_addr).await.is_err() {
+                    if TcpStream::connect(format!("127.0.0.1:{}", self.src_port)).await.is_err() {
                         warn!(
                             "Error establishing connection for stopping the Portforwader. Maybe the server is already stopped.");
                     };


### PR DESCRIPTION
This commits adds a new subcommand to the consumer CLI, `stop-scrcpy`. This should fix #2.

Note: Currently, the `stop-scrcpy` subcommand doesn't actually stop scrcpy for device, if both supplier and consumer are running on the same machine ( #16)
