### PR TITLE
Fix error due to #10

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -356,7 +356,7 @@ impl Cli {
 
                 #[cfg(unix)]
                 {
-                    use crate::util::{PID_FILE, STDERR_LOGFILE, STDOUT_LOGFILE};
+                    use adborc::util::{PID_FILE, STDERR_LOGFILE, STDOUT_LOGFILE};
                     use daemonize::Daemonize;
                     use log::info;
                     use std::env;


### PR DESCRIPTION
The PR #10 introduced a bug for *nix based
systems. The bug was caused because the changes
required to move `cli` out of library and into
the binary were not implmented for *nix based
systems. This commit fixes that.