### PR TITLE
Limit usage of serde_json to `request` module

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,13 +323,12 @@ fn map_processing_error(error: Error, res_type: ResponseType) -> String {
     }
 }
 
-fn send_request<T>(spec_request: T, res_type: ResponseType, client: &TCPClient) -> Response
+fn send_request<T>(request: T, res_type: ResponseType, client: &TCPClient) -> Response
 where
     T: GetRequest + Serialize,
 {
-    let request = spec_request.get_request();
     let response = client
-        .send_request(&request, None)
+        .send_request(request, None)
         .unwrap_or_else(|e| map_processing_error(e, res_type));
     Response::from_str(&response).unwrap()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,6 @@ use adborc::util::{
 };
 use clap::{Parser, Subcommand};
 use log::error;
-use serde::Serialize;
 use std::collections::HashSet;
 use std::io::{self, Error};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
@@ -325,7 +324,7 @@ fn map_processing_error(error: Error, res_type: ResponseType) -> String {
 
 fn send_request<T>(request: T, res_type: ResponseType, client: &TCPClient) -> Response
 where
-    T: GetRequest + Serialize,
+    T: ToJson,
 {
     let response = client
         .send_request(request, None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //! // Construct a request to start the marketmaker.
 //! let request = Request::System(SysStateRequest::StartMarketMaker);
 //! let response = client.send_request(&request, None).unwrap();
-//! let expected_response = SysStateResponse::StartMarketMakerSuccess;
+//! let expected_response = Response(System(SysStateResponse::StartMarketMakerSuccess));
 //! assert_eq!(response, serde_json::to_string(&expected_response).unwrap());
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! # use std::thread;
 //! use adborc::{
 //!     market::{SysState, request::
-//!             {Request, Response, SysStateRequest, SysStateResponse}},
+//!             {Request, ToJson, SysStateRequest, SysStateResponse}},
 //!     net::TCPClient,
 //!     util::SysStateDefaultConfig
 //! };
@@ -72,10 +72,10 @@
 //!
 //! let client = TCPClient::new("localhost", SysStateDefaultConfig::BIND_PORT).unwrap();
 //! // Construct a request to start the marketmaker.
-//! let request = Request::System(SysStateRequest::StartMarketMaker);
-//! let response = client.send_request(&request, None).unwrap();
-//! let expected_response = Response::System(SysStateResponse::StartMarketMakerSuccess);
-//! assert_eq!(response, serde_json::to_string(&expected_response).unwrap());
+//! let request = SysStateRequest::StartMarketMaker;
+//! let response = client.send_request(request, None).unwrap();
+//! let expected_response = SysStateResponse::StartMarketMakerSuccess;
+//! assert_eq!(response, expected_response.to_json());
 //! ```
 //!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! # use std::thread;
 //! use adborc::{
 //!     market::{SysState, request::
-//!             {Request, SysStateRequest, SysStateResponse}},
+//!             {Request, Response, SysStateRequest, SysStateResponse}},
 //!     net::TCPClient,
 //!     util::SysStateDefaultConfig
 //! };
@@ -74,7 +74,7 @@
 //! // Construct a request to start the marketmaker.
 //! let request = Request::System(SysStateRequest::StartMarketMaker);
 //! let response = client.send_request(&request, None).unwrap();
-//! let expected_response = Response(System(SysStateResponse::StartMarketMakerSuccess));
+//! let expected_response = Response::System(SysStateResponse::StartMarketMakerSuccess);
 //! assert_eq!(response, serde_json::to_string(&expected_response).unwrap());
 //! ```
 //!

--- a/src/market.rs
+++ b/src/market.rs
@@ -1145,7 +1145,7 @@ mod tests {
     use super::*;
     use crate::net::TCPClient;
     use crate::util::{test_with_logs, SysStateDefaultConfig};
-    use request::{MarketMakerRequest, MarketMakerResponse, Request};
+    use request::{MarketMakerRequest, MarketMakerResponse};
     use serial_test::serial;
 
     #[test]
@@ -1159,24 +1159,24 @@ mod tests {
 
         let client = TCPClient::new("localhost", SysStateDefaultConfig::BIND_PORT).unwrap();
 
-        let request = Request::System(SysStateRequest::GetState);
-        let response = client.send_request(&request, None).unwrap();
+        let request = SysStateRequest::GetState;
+        let response = client.send_request(request, None).unwrap();
         let expected_response = SysStateResponse::CurrentSysState {
             state: SysStateMin::default(),
         }
         .to_json();
         assert_eq!(response, expected_response);
 
-        let request = Request::System(SysStateRequest::GetPeerId);
-        let response = client.send_request(&request, None).unwrap();
+        let request = SysStateRequest::GetPeerId;
+        let response = client.send_request(request, None).unwrap();
         let pub_key = SystemKeypair::get_public_key().map_or(String::new(), base64::encode);
         let expected_response = SysStateResponse::PeerId { peer_id: pub_key }.to_json();
         assert_eq!(response, expected_response);
 
         System::start_market_maker().unwrap();
 
-        let request = Request::MarketMaker(MarketMakerRequest::Test);
-        let response = client.send_request(&request, None).unwrap();
+        let request = MarketMakerRequest::Test;
+        let response = client.send_request(request, None).unwrap();
         let expected_response = MarketMakerResponse::Test.to_json();
         assert_eq!(response, expected_response);
 

--- a/src/market/consumer.rs
+++ b/src/market/consumer.rs
@@ -762,7 +762,10 @@ impl Consumer {
         let mm_addr = mm_addr.unwrap();
         let client = TCPClient::from(mm_addr);
         let response = client.send_request(&request, None)?;
-        let response = MarketMakerResponse::from_str(&response)?;
+        let response = MarketMakerResponse::from_str(&response).map_err(|e| {
+            error!("Error parsing response from Market Maker: {}", e);
+            io::Error::new(io::ErrorKind::Other, e.to_string())
+        })?;
         match response {
             MarketMakerResponse::ScrcpyTunnelSuccess => Ok(portforwarder),
             MarketMakerResponse::ScrcpyTunnelFailure { reason } => {

--- a/src/market/consumer.rs
+++ b/src/market/consumer.rs
@@ -305,7 +305,7 @@ impl ConsumerState {
 }
 
 impl Display for ConsumerStateMin {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             r"Current Consumer Status:
@@ -322,7 +322,7 @@ impl Display for ConsumerStateMin {
 }
 
 impl Display for ConsumerState {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             r"Current Consumer Status:
@@ -388,7 +388,7 @@ impl Consumer {
             consumer: consumer_spec,
         });
         let response = client.send_request(&connect_request, None)?;
-        let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+        let response = MarketMakerResponse::from_str(&response).unwrap();
         if let MarketMakerResponse::ConsumerConnected {
             consumer: consumer_spec,
             pub_key,
@@ -433,8 +433,7 @@ impl Consumer {
             let mm_addr = mm_addr.unwrap();
             let client = TCPClient::from(mm_addr);
             let heartbeat_request = Request::MarketMaker(MarketMakerRequest::ConsumerHeartBeat);
-            let heartbeat_request = serde_json::to_string(&heartbeat_request).unwrap();
-            let response = match client.send(heartbeat_request.as_str(), None) {
+            let response = match client.send_request(&heartbeat_request, None) {
                 Ok(response) => response,
                 Err(e) => {
                     error!("Failed to send heartbeat to Market Maker: {}", e);
@@ -442,7 +441,7 @@ impl Consumer {
                     break;
                 }
             };
-            let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+            let response = MarketMakerResponse::from_str(&response).unwrap();
             if let MarketMakerResponse::HeartBeatResponse = response {
                 debug!("Heartbeat sent successfully.");
             } else {
@@ -763,7 +762,7 @@ impl Consumer {
         let mm_addr = mm_addr.unwrap();
         let client = TCPClient::from(mm_addr);
         let response = client.send_request(&request, None)?;
-        let response = serde_json::from_str::<MarketMakerResponse>(&response)?;
+        let response = MarketMakerResponse::from_str(&response)?;
         match response {
             MarketMakerResponse::ScrcpyTunnelSuccess => Ok(portforwarder),
             MarketMakerResponse::ScrcpyTunnelFailure { reason } => {
@@ -798,10 +797,10 @@ impl Consumer {
         let is_market_maker = || ConsumerState::verify_market_maker(&peer_id);
         match request {
             // Client requests.
-            ConsumerRequest::Test => serde_json::to_string(&ConsumerResponse::Test).unwrap(),
+            ConsumerRequest::Test => ConsumerResponse::Test.to_json(),
             ConsumerRequest::Status if peer_addr.ip().is_loopback() => {
                 let state = ConsumerState::get_min_state();
-                serde_json::to_string(&ConsumerResponse::Status { state }).unwrap()
+                ConsumerResponse::Status { state }.to_json()
             }
             ConsumerRequest::GetAvailableDevices if peer_addr.ip().is_loopback() => {
                 // Get available devices from the market maker.
@@ -810,38 +809,36 @@ impl Consumer {
 
                 if mm_addr.is_none() {
                     error!("Could not get marketmaker address.");
-                    return serde_json::to_string(&ConsumerResponse::ErrorGettingDevices {
+                    return ConsumerResponse::ErrorGettingDevices {
                         reason: "Could not get marketmaker address.".to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let mm_addr = mm_addr.unwrap();
                 let client = TCPClient::from(mm_addr);
                 let response = client.send_request(&data, None);
                 if response.is_err() {
-                    return serde_json::to_string(&ConsumerResponse::ErrorGettingDevices {
+                    return ConsumerResponse::ErrorGettingDevices {
                         reason: format!(
                             "Could not get available devices from Market Maker: {}",
                             response.err().unwrap()
                         ),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let response = response.unwrap();
-                let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+                let response = MarketMakerResponse::from_str(&response).unwrap();
                 match response {
                     MarketMakerResponse::AvailableDevices { devices } => {
-                        serde_json::to_string(&ConsumerResponse::AvailableDevices { devices })
-                            .unwrap()
+                        ConsumerResponse::AvailableDevices { devices }.to_json()
                     }
                     MarketMakerResponse::ErrorGettingDevices { reason } => {
-                        serde_json::to_string(&ConsumerResponse::ErrorGettingDevices { reason })
-                            .unwrap()
+                        ConsumerResponse::ErrorGettingDevices { reason }.to_json()
                     }
-                    _ => serde_json::to_string(&ConsumerResponse::InvalidRequest {
-                        request: serde_json::to_string(&response).unwrap(),
-                    })
-                    .unwrap(),
+                    _ => ConsumerResponse::InvalidRequest {
+                        request: response.to_json(),
+                    }
+                    .to_json(),
                 }
             }
             ConsumerRequest::GetDevicesByFilter { filter_vec } if peer_addr.ip().is_loopback() => {
@@ -852,42 +849,41 @@ impl Consumer {
 
                 if mm_addr.is_none() {
                     error!("Could not get marketmaker address.");
-                    return serde_json::to_string(&ConsumerResponse::ErrorGettingDevices {
+                    return ConsumerResponse::ErrorGettingDevices {
                         reason: "Could not get marketmaker address.".to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let mm_addr = mm_addr.unwrap();
                 let client = TCPClient::from(mm_addr);
                 let response = client.send_request(&data, None);
                 if response.is_err() {
-                    return serde_json::to_string(&ConsumerResponse::ErrorGettingDevices {
+                    return ConsumerResponse::ErrorGettingDevices {
                         reason: format!(
                             "Could not get available devices from Market Maker: {}",
                             response.err().unwrap()
                         ),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let response = response.unwrap();
-                let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+                let response = MarketMakerResponse::from_str(&response).unwrap();
                 match response {
                     MarketMakerResponse::DevicesByFilter {
                         devices,
                         filter_vec,
-                    } => serde_json::to_string(&ConsumerResponse::DevicesByFilter {
+                    } => ConsumerResponse::DevicesByFilter {
                         devices,
                         filter_vec,
-                    })
-                    .unwrap(),
-                    MarketMakerResponse::ErrorGettingDevices { reason } => {
-                        serde_json::to_string(&ConsumerResponse::ErrorGettingDevices { reason })
-                            .unwrap()
                     }
-                    _ => serde_json::to_string(&ConsumerResponse::InvalidRequest {
-                        request: serde_json::to_string(&response).unwrap(),
-                    })
-                    .unwrap(),
+                    .to_json(),
+                    MarketMakerResponse::ErrorGettingDevices { reason } => {
+                        ConsumerResponse::ErrorGettingDevices { reason }.to_json()
+                    }
+                    _ => ConsumerResponse::InvalidRequest {
+                        request: response.to_json(),
+                    }
+                    .to_json(),
                 }
             }
             ConsumerRequest::ReserveDevice { device_id, no_use }
@@ -900,25 +896,25 @@ impl Consumer {
                 let mm_addr = ConsumerState::get_addr();
                 if mm_addr.is_none() {
                     error!("Could not get marketmaker address.");
-                    return serde_json::to_string(&ConsumerResponse::DeviceNotReserved {
+                    return ConsumerResponse::DeviceNotReserved {
                         reason: "Could not get marketmaker address.".to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let mm_addr = mm_addr.unwrap();
                 let client = TCPClient::from(mm_addr);
                 let response = client.send_request(&data, None);
                 if response.is_err() {
-                    return serde_json::to_string(&ConsumerResponse::DeviceNotReserved {
+                    return ConsumerResponse::DeviceNotReserved {
                         reason: format!(
                             "Could not reserve device from Market Maker: {}",
                             response.err().unwrap()
                         ),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let response = response.unwrap();
-                let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+                let response = MarketMakerResponse::from_str(&response).unwrap();
                 match response {
                     MarketMakerResponse::DeviceReserved {
                         mut device,
@@ -947,31 +943,29 @@ impl Consumer {
 
                             client.send_no_wait(&data);
                             // Return error back to client.
-                            serde_json::to_string(&ConsumerResponse::DeviceNotReserved {
+                            ConsumerResponse::DeviceNotReserved {
                                 reason: format!("Could not reserve device: {}", e),
-                            })
-                            .unwrap()
+                            }
+                            .to_json()
                         } else {
-                            serde_json::to_string(&ConsumerResponse::DeviceReserved { device })
-                                .unwrap()
+                            ConsumerResponse::DeviceReserved { device }.to_json()
                         }
                     }
                     MarketMakerResponse::DeviceNotReserved { reason } => {
-                        serde_json::to_string(&ConsumerResponse::DeviceNotReserved { reason })
-                            .unwrap()
+                        ConsumerResponse::DeviceNotReserved { reason }.to_json()
                     }
-                    _ => serde_json::to_string(&ConsumerResponse::InvalidRequest {
-                        request: serde_json::to_string(&response).unwrap(),
-                    })
-                    .unwrap(),
+                    _ => ConsumerResponse::InvalidRequest {
+                        request: response.to_json(),
+                    }
+                    .to_json(),
                 }
             }
             ConsumerRequest::ReleaseDevice { device_id } if peer_addr.ip().is_loopback() => {
                 if !ConsumerState::is_device_reserved(&device_id) {
-                    return serde_json::to_string(&ConsumerResponse::DeviceNotReleased {
+                    return ConsumerResponse::DeviceNotReleased {
                         reason: "Cannot release a device that is not reserved.".to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 // Send release request to the marketmaker device from the market maker.
                 let data = Request::MarketMaker(MarketMakerRequest::ReleaseDevice {
@@ -980,26 +974,26 @@ impl Consumer {
                 let mm_addr = ConsumerState::get_addr();
                 if mm_addr.is_none() {
                     error!("Could not get marketmaker address.");
-                    return serde_json::to_string(&ConsumerResponse::DeviceNotReleased {
+                    return ConsumerResponse::DeviceNotReleased {
                         reason: "Could not get marketmaker address.".to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let mm_addr = mm_addr.unwrap();
                 let client = TCPClient::from(mm_addr);
 
                 let response = client.send_request(&data, None);
                 if response.is_err() {
-                    return serde_json::to_string(&ConsumerResponse::DeviceNotReleased {
+                    return ConsumerResponse::DeviceNotReleased {
                         reason: format!(
                             "Could not release device from Market Maker: {}",
                             response.err().unwrap()
                         ),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let response = response.unwrap();
-                let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+                let response = MarketMakerResponse::from_str(&response).unwrap();
                 match response {
                     MarketMakerResponse::DeviceReleased => {
                         // Remove the port forwarder for the device.
@@ -1007,17 +1001,15 @@ impl Consumer {
                         ConsumerState::remove_device(&device_id);
                         ScrCpyState::remove_portforwarder(&device_id);
                         // Return the response.
-                        serde_json::to_string(&ConsumerResponse::DeviceReleased { device_id })
-                            .unwrap()
+                        ConsumerResponse::DeviceReleased { device_id }.to_json()
                     }
                     MarketMakerResponse::DeviceNotReleased { reason } => {
-                        serde_json::to_string(&ConsumerResponse::DeviceNotReleased { reason })
-                            .unwrap()
+                        ConsumerResponse::DeviceNotReleased { reason }.to_json()
                     }
-                    _ => serde_json::to_string(&ConsumerResponse::DeviceNotReleased {
+                    _ => ConsumerResponse::DeviceNotReleased {
                         reason: "Unknown operation".to_string(),
-                    })
-                    .unwrap(),
+                    }
+                    .to_json(),
                 }
             }
 
@@ -1025,35 +1017,35 @@ impl Consumer {
                 // Send release request to the marketmaker.
                 let num_devices = ConsumerState::get_number_of_devices();
                 if num_devices == 0 {
-                    return serde_json::to_string(&ConsumerResponse::AllDeviceReleaseFailure {
+                    return ConsumerResponse::AllDeviceReleaseFailure {
                         reason: "No devices reserved.".to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let data = Request::MarketMaker(MarketMakerRequest::ReleaseAllDevices);
                 let mm_addr = ConsumerState::get_addr();
                 if mm_addr.is_none() {
                     error!("Could not get marketmaker address.");
-                    return serde_json::to_string(&ConsumerResponse::AllDeviceReleaseFailure {
+                    return ConsumerResponse::AllDeviceReleaseFailure {
                         reason: "Could not get marketmaker address.".to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let mm_addr = mm_addr.unwrap();
                 let client = TCPClient::from(mm_addr);
 
                 let response = client.send_request(&data, None);
                 if response.is_err() {
-                    return serde_json::to_string(&ConsumerResponse::AllDeviceReleaseFailure {
+                    return ConsumerResponse::AllDeviceReleaseFailure {
                         reason: format!(
                             "Could not release device from Market Maker: {}",
                             response.err().unwrap()
                         ),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 let response = response.unwrap();
-                let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+                let response = MarketMakerResponse::from_str(&response).unwrap();
                 match response {
                     MarketMakerResponse::AllDeviceReleaseSuccess => {
                         // Remove the port forwarder for the device.
@@ -1062,28 +1054,26 @@ impl Consumer {
                         ScrCpyState::kill_all();
                         ScrCpyState::remove_all_port_forwarders();
                         // Return the response.
-                        serde_json::to_string(&ConsumerResponse::AllDeviceReleaseSuccess).unwrap()
+                        ConsumerResponse::AllDeviceReleaseSuccess.to_json()
                     }
                     MarketMakerResponse::AllDeviceReleaseFailure { reason } => {
-                        serde_json::to_string(&ConsumerResponse::AllDeviceReleaseFailure { reason })
-                            .unwrap()
+                        ConsumerResponse::AllDeviceReleaseFailure { reason }.to_json()
                     }
-                    _ => serde_json::to_string(&ConsumerResponse::AllDeviceReleaseFailure {
+                    _ => ConsumerResponse::AllDeviceReleaseFailure {
                         reason: "Unknown operation".to_string(),
-                    })
-                    .unwrap(),
+                    }
+                    .to_json(),
                 }
             }
             ConsumerRequest::UseDevice { device_id } => {
                 let result = Consumer::use_device(&device_id);
                 if let Err(e) = result {
-                    serde_json::to_string(&ConsumerResponse::UseDeviceFailure {
+                    ConsumerResponse::UseDeviceFailure {
                         reason: format!("{}", e),
-                    })
-                    .unwrap()
+                    }
+                    .to_json()
                 } else {
-                    serde_json::to_string(&ConsumerResponse::UseDeviceSuccess { device_id })
-                        .unwrap()
+                    ConsumerResponse::UseDeviceSuccess { device_id }.to_json()
                 }
             }
 
@@ -1092,33 +1082,31 @@ impl Consumer {
                 scrcpy_args,
             } if peer_addr.ip().is_loopback() => {
                 if !ConsumerState::is_device_reserved(&device_id) {
-                    return serde_json::to_string(&ConsumerResponse::StartScrCpyFailure {
+                    return ConsumerResponse::StartScrCpyFailure {
                         reason: "Cannot start scrcpy for a device that is not reserved."
                             .to_string(),
-                    })
-                    .unwrap();
+                    }
+                    .to_json();
                 }
                 if let Err(e) = Consumer::start_scrcpy(&device_id, scrcpy_args) {
-                    serde_json::to_string(&ConsumerResponse::StartScrCpyFailure {
+                    ConsumerResponse::StartScrCpyFailure {
                         reason: format!("Could not start scrcpy: {}", e),
-                    })
-                    .unwrap()
+                    }
+                    .to_json()
                 } else {
-                    serde_json::to_string(&ConsumerResponse::StartScrCpySuccess { device_id })
-                        .unwrap()
+                    ConsumerResponse::StartScrCpySuccess { device_id }.to_json()
                 }
             }
 
             ConsumerRequest::SetScrCpyDefaults { scrcpy_args } if peer_addr.ip().is_loopback() => {
                 ConsumerState::set_scrcpy_defaults(scrcpy_args.iter());
 
-                serde_json::to_string(&ConsumerResponse::ScrCpyDefaultsSet { args: scrcpy_args })
-                    .unwrap()
+                ConsumerResponse::ScrCpyDefaultsSet { args: scrcpy_args }.to_json()
             }
 
             ConsumerRequest::GetScrCpyDefaults if peer_addr.ip().is_loopback() => {
                 let args = ConsumerState::get_scrcpy_args().into_iter().collect();
-                serde_json::to_string(&ConsumerResponse::ScrCpyDefaults { args }).unwrap()
+                ConsumerResponse::ScrCpyDefaults { args }.to_json()
             }
 
             // Requests from Market Maker.
@@ -1131,14 +1119,14 @@ impl Consumer {
                         ScrCpyState::remove_portforwarder(&device_id_clone);
                     }
                 });
-                serde_json::to_string(&ConsumerResponse::DeviceReleased { device_id }).unwrap()
+                ConsumerResponse::DeviceReleased { device_id }.to_json()
             }
             ConsumerRequest::MarketMakerTerminating if is_market_maker() => {
                 thread::spawn(Consumer::market_maker_terminate);
-                serde_json::to_string(&ConsumerResponse::TerminationAcknowledged).unwrap()
+                ConsumerResponse::TerminationAcknowledged.to_json()
             }
 
-            _ => serde_json::to_string(&ConsumerResponse::RequestNotAllowed).unwrap(),
+            _ => ConsumerResponse::RequestNotAllowed.to_json(),
         }
     }
 }

--- a/src/market/consumer/tests.rs
+++ b/src/market/consumer/tests.rs
@@ -29,7 +29,7 @@ async fn test_status() {
         .await
         .unwrap();
 
-    let response = serde_json::from_str::<ConsumerResponse>(&response).unwrap();
+    let response = ConsumerResponse::from_str(&response).unwrap();
     match response {
         ConsumerResponse::Status { state } => {
             let expected_state = ConsumerStateMin {

--- a/src/market/marketmaker.rs
+++ b/src/market/marketmaker.rs
@@ -590,10 +590,8 @@ impl MarketMaker {
                             if let Some(port) = port {
                                 if let Ok(client) = TCPClient::new(host.as_str(), port) {
                                     let request =
-                                        Request::Consumer(ConsumerRequest::SupplierDisconnected {
-                                            device_id,
-                                        });
-                                    client.send_no_wait(&request);
+                                        ConsumerRequest::SupplierDisconnected { device_id };
+                                    client.send_no_wait(request);
                                 }
                             }
                         }
@@ -618,10 +616,10 @@ impl MarketMaker {
             let port = MarketMakerState::get_consumer_port(&consumer_pub_key);
             if let Some(port) = port {
                 if let Ok(client) = TCPClient::new(host.as_str(), port) {
-                    let request = Request::Consumer(ConsumerRequest::SupplierDisconnected {
+                    let request = ConsumerRequest::SupplierDisconnected {
                         device_id: device_id.clone(),
-                    });
-                    client.send_no_wait(&request);
+                    };
+                    client.send_no_wait(request);
                 }
             }
             MarketMaker::release_device(&device_id);
@@ -649,10 +647,10 @@ impl MarketMaker {
             let host = supplier.bind_host.as_str();
             let port = supplier.bind_port;
             if let Ok(client) = TCPClient::new(host, port) {
-                let request = Request::Supplier(SupplierRequest::StopSecureTunnel {
+                let request = SupplierRequest::StopSecureTunnel {
                     device_id: device.device_id,
-                });
-                client.send_no_wait(&request);
+                };
+                client.send_no_wait(request);
             }
         }
     }
@@ -676,8 +674,8 @@ impl MarketMaker {
             let host = supplier.0.as_str();
             let port = supplier.1;
             if let Ok(client) = TCPClient::new(host, port) {
-                let request = Request::System(SysStateRequest::SupplierMarketMakerTerminating);
-                client.send_no_wait(&request);
+                let request = SysStateRequest::SupplierMarketMakerTerminating;
+                client.send_no_wait(request);
             }
         }
 
@@ -685,8 +683,8 @@ impl MarketMaker {
             let host = consumer.0.as_str();
             let port = consumer.1;
             if let Ok(client) = TCPClient::new(host, port) {
-                let request = Request::System(SysStateRequest::ConsumerMarketMakerTerminating);
-                client.send_no_wait(&request);
+                let request = SysStateRequest::ConsumerMarketMakerTerminating;
+                client.send_no_wait(request);
             }
         }
         thread::sleep(Duration::from_millis(1000));
@@ -886,10 +884,10 @@ impl MarketMaker {
                     let host = consumer.bind_host.as_str();
                     let port = consumer.bind_port;
                     if let Ok(client) = TCPClient::new(host, port) {
-                        let request = Request::Consumer(ConsumerRequest::SupplierDisconnected {
+                        let request = ConsumerRequest::SupplierDisconnected {
                             device_id: device_id.clone(),
-                        });
-                        client.send_no_wait(&request);
+                        };
+                        client.send_no_wait(request);
                     }
                 }
 
@@ -914,11 +912,8 @@ impl MarketMaker {
                         let port = MarketMakerState::get_consumer_port(&consumer_pub_key);
                         if let Some(port) = port {
                             if let Ok(client) = TCPClient::new(host.as_str(), port) {
-                                let request =
-                                    Request::Consumer(ConsumerRequest::SupplierDisconnected {
-                                        device_id,
-                                    });
-                                client.send_no_wait(&request);
+                                let request = ConsumerRequest::SupplierDisconnected { device_id };
+                                client.send_no_wait(request);
                             }
                         }
                     }
@@ -1059,12 +1054,12 @@ impl MarketMaker {
                     let host = supplier.bind_host.as_str();
                     let port = supplier.bind_port;
                     if let Ok(client) = TCPClient::new(host, port) {
-                        let request = Request::Supplier(SupplierRequest::StartSecureTunnel {
+                        let request = SupplierRequest::StartSecureTunnel {
                             device_id: device.device_id.clone(),
                             port: device.available_at_port,
                             pub_key: peer_id_str.clone(),
-                        });
-                        let response = client.send_request(&request, None);
+                        };
+                        let response = client.send_request(request, None);
                         if response.is_err() {
                             return MarketMakerResponse::DeviceNotReserved {
                                 reason: "Could not connect to supplier".to_string(),
@@ -1154,14 +1149,14 @@ impl MarketMaker {
                     let host = supplier.bind_host.as_str();
                     let supplier_port = supplier.bind_port;
                     if let Ok(client) = TCPClient::new(host, supplier_port) {
-                        let request = Request::Supplier(SupplierRequest::StartScrcpyTunnel {
+                        let request = SupplierRequest::StartScrcpyTunnel {
                             device_id,
                             port,
                             peer_id: peer_id_str.clone(),
                             consumer_host,
                             scrcpy_port,
-                        });
-                        let response = client.send_request(&request, None);
+                        };
+                        let response = client.send_request(request, None);
                         if response.is_err() {
                             return MarketMakerResponse::ScrcpyTunnelFailure {
                                 reason: "Could not connect to supplier".to_string(),

--- a/src/market/marketmaker/tests.rs
+++ b/src/market/marketmaker/tests.rs
@@ -14,10 +14,10 @@ fn test_status_request() {
     let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     let peer_id = Arc::new(Vec::new());
     let response = MarketMaker::process_request(request, peer_addr, peer_id);
-    let expected_response = serde_json::to_string(&MarketMakerResponse::Status {
+    let expected_response = MarketMakerResponse::Status {
         state: MarketMakerMinState::default(),
-    })
-    .unwrap();
+    }
+    .to_json();
     assert_eq!(response, expected_response);
 }
 
@@ -44,7 +44,7 @@ async fn test_supplier_connect() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::SupplierConnected { supplier, pub_key } => {
             assert_eq!(base64::decode(supplier.pub_key).unwrap(), peer_pub_key);
@@ -98,7 +98,7 @@ async fn test_supplier_connect_secure_mode() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::SupplierConnected { supplier, pub_key } => {
             assert_eq!(base64::decode(supplier.pub_key).unwrap(), peer_pub_key);
@@ -153,7 +153,7 @@ async fn test_supplier_connect_pub_key_mismatch() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::SupplierNotConnected { reason } => {
             assert_eq!(reason, "Public key does not match peer id");
@@ -193,7 +193,7 @@ async fn test_supplier_connect_already_connected() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::SupplierNotConnected { reason } => {
             assert_eq!(reason, "Already connected");
@@ -240,7 +240,7 @@ async fn test_supplier_connect_not_in_whitelist() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::SupplierNotConnected { reason } => {
             assert_eq!(reason, "Not in whitelist");
@@ -283,7 +283,7 @@ async fn test_consumer_connect() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::ConsumerConnected { consumer, pub_key } => {
             assert_eq!(base64::decode(consumer.pub_key).unwrap(), peer_pub_key);
@@ -335,7 +335,7 @@ async fn test_consumer_connect_pub_key_mismatch() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::ConsumerNotConnected { reason } => {
             assert_eq!(reason, "Public key does not match peer id");
@@ -375,7 +375,7 @@ async fn test_consumer_connect_already_connected() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::ConsumerNotConnected { reason } => {
             assert_eq!(reason, "Already connected");
@@ -422,7 +422,7 @@ async fn test_consumer_connect_not_in_whitelist() {
         task::spawn_blocking(move || MarketMaker::process_request(request, peer_addr, peer_id))
             .await
             .unwrap();
-    let response = serde_json::from_str::<MarketMakerResponse>(&response).unwrap();
+    let response = MarketMakerResponse::from_str(&response).unwrap();
     match response {
         MarketMakerResponse::ConsumerNotConnected { reason } => {
             assert_eq!(reason, "Not in whitelist");

--- a/src/market/request.rs
+++ b/src/market/request.rs
@@ -6,10 +6,12 @@ use marketmaker::MarketMakerMinState;
 use serde::Serialize;
 use std::str::FromStr;
 
+/// Wraps the request in the required `Request` enum.
 pub trait GetRequest {
     fn get_request(self) -> Request;
 }
 
+/// Wraps the response in the required `Response` enum and serializes it.
 pub trait ToJson {
     fn to_json(self) -> String;
 }
@@ -23,6 +25,12 @@ pub enum Request {
     Supplier(SupplierRequest),
     Consumer(ConsumerRequest),
 }
+
+// impl GetRequest for Request {
+//     fn get_request(self) -> Request {
+//         self
+//     }
+// }
 
 /// Wrapper enum for all the possible responses that can be sent from the
 /// network node.

--- a/src/market/request.rs
+++ b/src/market/request.rs
@@ -422,9 +422,6 @@ pub enum MarketMakerResponse {
     InvalidRequest {
         request: String,
     },
-    RequestProcessingError {
-        reason: String,
-    },
 }
 
 impl Display for MarketMakerResponse {
@@ -547,9 +544,6 @@ impl Display for MarketMakerResponse {
             MarketMakerResponse::InvalidRequest { request } => {
                 write!(f, "Invalid request: {}", request)
             }
-            MarketMakerResponse::RequestProcessingError { reason } => {
-                write!(f, "Error processing request: {}", reason)
-            }
         }
     }
 }
@@ -634,9 +628,6 @@ pub enum SupplierResponse {
     InvalidRequest {
         request: String,
     },
-    RequestProcessingError {
-        reason: String,
-    },
 }
 
 impl Display for SupplierResponse {
@@ -693,9 +684,6 @@ impl Display for SupplierResponse {
             SupplierResponse::RequestNotAllowed => write!(f, "Request not allowed"),
             SupplierResponse::InvalidRequest { request } => {
                 write!(f, "Invalid request: {}", request)
-            }
-            SupplierResponse::RequestProcessingError { reason } => {
-                write!(f, "Error processing request: {}", reason)
             }
         }
     }
@@ -795,9 +783,6 @@ pub enum ConsumerResponse {
     InvalidRequest {
         request: String,
     },
-    RequestProcessingError {
-        reason: String,
-    },
 }
 
 impl Display for ConsumerResponse {
@@ -883,9 +868,6 @@ impl Display for ConsumerResponse {
             ConsumerResponse::RequestNotAllowed => write!(f, "Request not allowed"),
             ConsumerResponse::InvalidRequest { request } => {
                 write!(f, "Invalid request: {}", request)
-            }
-            ConsumerResponse::RequestProcessingError { reason } => {
-                write!(f, "Error processing request: {}", reason)
             }
         }
     }

--- a/src/market/request.rs
+++ b/src/market/request.rs
@@ -6,11 +6,6 @@ use marketmaker::MarketMakerMinState;
 use serde::Serialize;
 use std::str::FromStr;
 
-/// Wraps the request in the required `Request` enum.
-pub trait GetRequest {
-    fn get_request(self) -> Request;
-}
-
 /// Wraps the response in the required `Response` enum and serializes it.
 pub trait ToJson {
     fn to_json(self) -> String;
@@ -25,12 +20,6 @@ pub enum Request {
     Supplier(SupplierRequest),
     Consumer(ConsumerRequest),
 }
-
-// impl GetRequest for Request {
-//     fn get_request(self) -> Request {
-//         self
-//     }
-// }
 
 /// Wrapper enum for all the possible responses that can be sent from the
 /// network node.
@@ -902,27 +891,27 @@ impl Display for ConsumerResponse {
     }
 }
 
-impl GetRequest for SysStateRequest {
-    fn get_request(self) -> Request {
-        Request::System(self)
+impl ToJson for SysStateRequest {
+    fn to_json(self) -> String {
+        serde_json::to_string(&Request::System(self)).unwrap()
     }
 }
 
-impl GetRequest for MarketMakerRequest {
-    fn get_request(self) -> Request {
-        Request::MarketMaker(self)
+impl ToJson for MarketMakerRequest {
+    fn to_json(self) -> String {
+        serde_json::to_string(&Request::MarketMaker(self)).unwrap()
     }
 }
 
-impl GetRequest for SupplierRequest {
-    fn get_request(self) -> Request {
-        Request::Supplier(self)
+impl ToJson for SupplierRequest {
+    fn to_json(self) -> String {
+        serde_json::to_string(&Request::Supplier(self)).unwrap()
     }
 }
 
-impl GetRequest for ConsumerRequest {
-    fn get_request(self) -> Request {
-        Request::Consumer(self)
+impl ToJson for ConsumerRequest {
+    fn to_json(self) -> String {
+        serde_json::to_string(&Request::Consumer(self)).unwrap()
     }
 }
 

--- a/src/market/request.rs
+++ b/src/market/request.rs
@@ -3,6 +3,21 @@ use crate::util::adb_utils::ScrCpyArgs;
 use super::{supplier::SupplierStateMin, DeviceFilterVec, *};
 use consumer::ConsumerStateMin;
 use marketmaker::MarketMakerMinState;
+use serde::Serialize;
+use std::str::FromStr;
+
+pub trait GetRequest {
+    fn get_request(self) -> Request;
+}
+
+pub trait ToJson {
+    fn to_json(&self) -> String
+    where
+        Self: Serialize,
+    {
+        serde_json::to_string(self).unwrap()
+    }
+}
 
 /// Wrapper enum for all the possible requests that can be sent to the
 /// network node.
@@ -124,7 +139,7 @@ pub enum SysStateResponse {
 }
 
 impl Display for SysStateResponse {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             SysStateResponse::CurrentSysState { state } => write!(f, "{}", state),
             SysStateResponse::PeerId { peer_id } => write!(f, "PeerId: {}", peer_id),
@@ -367,7 +382,7 @@ pub enum MarketMakerResponse {
 }
 
 impl Display for MarketMakerResponse {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             MarketMakerResponse::Test => write!(f, "Test"),
             MarketMakerResponse::Status { state } => write!(f, "{}", state),
@@ -579,7 +594,7 @@ pub enum SupplierResponse {
 }
 
 impl Display for SupplierResponse {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             SupplierResponse::Test => write!(f, "Test"),
             SupplierResponse::Status { state } => write!(f, "{}", state),
@@ -740,7 +755,7 @@ pub enum ConsumerResponse {
 }
 
 impl Display for ConsumerResponse {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             ConsumerResponse::Test => write!(f, "Test"),
             ConsumerResponse::Status { state } => write!(f, "{}", state),
@@ -827,5 +842,70 @@ impl Display for ConsumerResponse {
                 write!(f, "Error processing request: {}", reason)
             }
         }
+    }
+}
+
+impl GetRequest for SysStateRequest {
+    fn get_request(self) -> Request {
+        Request::System(self)
+    }
+}
+
+impl GetRequest for MarketMakerRequest {
+    fn get_request(self) -> Request {
+        Request::MarketMaker(self)
+    }
+}
+
+impl GetRequest for SupplierRequest {
+    fn get_request(self) -> Request {
+        Request::Supplier(self)
+    }
+}
+
+impl GetRequest for ConsumerRequest {
+    fn get_request(self) -> Request {
+        Request::Consumer(self)
+    }
+}
+
+impl ToJson for SysStateResponse {}
+impl ToJson for MarketMakerResponse {}
+impl ToJson for SupplierResponse {}
+impl ToJson for ConsumerResponse {}
+
+impl FromStr for Request {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl FromStr for SysStateResponse {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl FromStr for MarketMakerResponse {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl FromStr for SupplierResponse {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl FromStr for ConsumerResponse {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }

--- a/src/market/request.rs
+++ b/src/market/request.rs
@@ -47,10 +47,15 @@ impl Display for Response {
 
 #[derive(Debug)]
 pub enum ParseResponseError {
+    /// Failed to parse the string as a valid JSON `Response`.
     BadResponse,
+    /// Failed to parse the Response JSON as a valid `SysStateResponse`.
     BadSystemResponse,
+    /// Failed to parse the Response JSON as a valid `MarketMakerResponse`.
     BadMarketMakerResponse,
+    /// Failed to parse the Response JSON as a valid `SupplierResponse`.
     BadSupplierResponse,
+    /// Failed to parse the Response JSON as a valid `ConsumerResponse`.
     BadConsumerResponse,
 }
 

--- a/src/market/supplier.rs
+++ b/src/market/supplier.rs
@@ -4,9 +4,7 @@ mod tests;
 use super::*;
 use crate::util::adb_utils;
 use portpicker;
-use request::{
-    MarketMakerRequest, MarketMakerResponse, Request, SupplierRequest, SupplierResponse,
-};
+use request::{MarketMakerRequest, MarketMakerResponse, SupplierRequest, SupplierResponse};
 use std::default::Default;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -389,10 +387,10 @@ impl Supplier {
         // Unwrapping of serialing/deserializing is safe, because we use request/response objects
         // that are known to be serializable/deserializable.
         let client = TCPClient::new(&mm_host, mm_port)?;
-        let supply_request = Request::MarketMaker(MarketMakerRequest::SupplierConnect {
+        let supply_request = MarketMakerRequest::SupplierConnect {
             supplier: supplier_spec,
-        });
-        let response = client.send_request(&supply_request, None)?;
+        };
+        let response = client.send_request(supply_request, None)?;
 
         let response = MarketMakerResponse::from_str(&response).unwrap();
         if let MarketMakerResponse::SupplierConnected {
@@ -441,8 +439,8 @@ impl Supplier {
 
             let mm_addr = mm_addr.unwrap();
             let client = TCPClient::from(mm_addr);
-            let heartbeat_request = Request::MarketMaker(MarketMakerRequest::SupplierHeartBeat);
-            let response = match client.send_request(&heartbeat_request, None) {
+            let heartbeat_request = MarketMakerRequest::SupplierHeartBeat;
+            let response = match client.send_request(heartbeat_request, None) {
                 Ok(response) => response,
                 Err(e) => {
                     error!("Failed to send heartbeat to Market Maker: {}", e);
@@ -472,8 +470,8 @@ impl Supplier {
         let mm_addr = SupplierState::get_addr();
         if let Some(addr) = mm_addr {
             let client = TCPClient::from(addr);
-            let disconnect_request = Request::MarketMaker(MarketMakerRequest::SupplierDisconnect);
-            client.send_no_wait(&disconnect_request);
+            let disconnect_request = MarketMakerRequest::SupplierDisconnect;
+            client.send_no_wait(disconnect_request);
         }
         SupplierState::reset_state();
     }
@@ -540,7 +538,7 @@ impl Supplier {
 
         // Unwrapping of serialing/deserializing is safe, because we use request/response objects
         // that are known to be serializable/deserializable.
-        let request = Request::MarketMaker(MarketMakerRequest::SupplyDevices { devices });
+        let request = MarketMakerRequest::SupplyDevices { devices };
         let mm_addr = SupplierState::get_addr();
         if mm_addr.is_none() {
             error!("Market Maker address is not set. Skipping supply devices.");
@@ -556,7 +554,7 @@ impl Supplier {
 
         let mm_addr = mm_addr.unwrap();
         let client = TCPClient::from(mm_addr);
-        let response = client.send_request(&request, None);
+        let response = client.send_request(request, None);
         if response.is_err() {
             error!(
                 "Failed to send SupplyDevices request to Market Maker: {}",
@@ -602,7 +600,7 @@ impl Supplier {
 
     /// Reclaim device from the Market Maker.
     fn reclaim_device(device_id: String, force: bool) -> String {
-        let request = Request::MarketMaker(MarketMakerRequest::ReclaimDevice { device_id, force });
+        let request = MarketMakerRequest::ReclaimDevice { device_id, force };
         let mm_addr = SupplierState::get_addr();
         if mm_addr.is_none() {
             error!("Market Maker address is not set. Skipping reclaim device.");
@@ -614,7 +612,7 @@ impl Supplier {
 
         let mm_addr = mm_addr.unwrap();
         let client = TCPClient::from(mm_addr);
-        let response = client.send_request(&request, None);
+        let response = client.send_request(request, None);
         if response.is_err() {
             error!(
                 "Failed to send ReclaimDevice request to Market Maker: {}",

--- a/src/market/supplier/tests.rs
+++ b/src/market/supplier/tests.rs
@@ -29,7 +29,7 @@ async fn test_status() {
         .await
         .unwrap();
 
-    let response = serde_json::from_str::<SupplierResponse>(&response).unwrap();
+    let response = SupplierResponse::from_str(&response).unwrap();
     match response {
         SupplierResponse::Status { state } => {
             let expected_state = SupplierStateMin {


### PR DESCRIPTION
This patch limits all usage of `serde_json` to `request` module. It does this by introducing ToJson trait which is implemented for all Request and Response types. Also, implementation of std::str::FromStr for `Request` and all response types is added.

In addition, this patch adds a `send_request` function to the `cli` module which abstracts a lot of the boilerplate code needed to send a request and receive a response.

A new `Response` wrapper type enum is introduced for all response types. This means, that this change breaks backwards compatibility with previous versions 